### PR TITLE
Added deserialize_ignore_any implementation

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -72,7 +72,6 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
     }
 
     fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        drop(self);
         visitor.visit_unit()
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -69,7 +69,11 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
         deserialize_bytes,
         deserialize_unit,
         deserialize_identifier,
-        deserialize_ignored_any,
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        drop(self);
+        visitor.visit_unit()
     }
 
     fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
@@ -399,6 +403,35 @@ mod tests {
         assert_eq!(None, buu.stomach_contents);
 
         connection.execute("DROP TABLE NullBuu", &[]).unwrap();
+    }
+
+    #[test]
+    fn mispelled_field_name() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Buu {
+            wants_candie: bool,
+        }
+
+        let connection = setup_and_connect_to_db();
+
+        connection.execute("CREATE TABLE IF NOT EXISTS SpellBuu (
+                    wants_candy BOOL NOT NULL
+        )", &[]).unwrap();
+
+        connection.execute("INSERT INTO SpellBuu (
+            wants_candy
+        ) VALUES ($1)",
+        &[&true]).unwrap();
+
+        let results = connection.query("SELECT wants_candy FROM SpellBuu", &[]).unwrap();
+
+        let row = results.get(0);
+
+        assert_eq!(
+            super::from_row::<Buu>(row),
+            Err(super::Error::Message(String::from("missing field `wants_candie`"))));
+
+        connection.execute("DROP TABLE SpellBuu", &[]).unwrap();
     }
 
     /*


### PR DESCRIPTION
deserialize_ignore_any is called when there is a column in the query set
that is not in the struct. Previously, this returned an error, but this
change makes it ignore the extra column.

This change is primariliy to improve the error reporting when the user
misspells a field name. Prior to this change this simply gives the error
InvalidType due to calling the deserialize_ignore_any function. With
this change, the error message becomes "missing field `field_name`"
which is much better.

The mechanics are that serde attempts to resolve all of the columns in
the query set first, thus returning the unhelpful error from
deserialize_ignore_any function before finding the field in the struct
that was never resolved and returning the more useful missing field
function.

It is also possible that it might be useful to define a struct that only
captures a subset of the columns from a sql query. I don't have a use
case for this, but is seems concievable.

The alternative solution would be to attempt to produce better error
messages in deserialize_ignore_any, such as indicating which column is
the source of the ignored any, but this information does not seem
readily available in that function.