### PR TITLE
Add better error messages when there is a type mismatch

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -72,7 +72,6 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
     }
 
     fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        drop(self);
         visitor.visit_unit()
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -69,7 +69,11 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
         deserialize_bytes,
         deserialize_unit,
         deserialize_identifier,
-        deserialize_ignored_any,
+    }
+
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        drop(self);
+        visitor.visit_unit()
     }
 
     fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
@@ -399,6 +403,35 @@ mod tests {
         assert_eq!(None, buu.stomach_contents);
 
         connection.execute("DROP TABLE NullBuu", &[]).unwrap();
+    }
+
+    #[test]
+    fn mispelled_field_name() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Buu {
+            wants_candie: bool,
+        }
+
+        let connection = setup_and_connect_to_db();
+
+        connection.execute("CREATE TABLE IF NOT EXISTS SpellBuu (
+                    wants_candy BOOL NOT NULL
+        )", &[]).unwrap();
+
+        connection.execute("INSERT INTO SpellBuu (
+            wants_candy
+        ) VALUES ($1)",
+        &[&true]).unwrap();
+
+        let results = connection.query("SELECT wants_candy FROM SpellBuu", &[]).unwrap();
+
+        let row = results.get(0);
+
+        assert_eq!(
+            super::from_row::<Buu>(row),
+            Err(super::Error::Message(String::from("missing field `wants_candie`"))));
+
+        connection.execute("DROP TABLE SpellBuu", &[]).unwrap();
     }
 
     /*

--- a/src/de.rs
+++ b/src/de.rs
@@ -52,7 +52,7 @@ macro_rules! get_value {
     ($this:ident, $v:ident, $fn_call:ident, $ty:ty) => {{
         $v.$fn_call($this.input.get_opt::<_, $ty>($this.index)
             .unwrap()
-            .map_err(|_| Error::InvalidType)?)
+            .map_err(|e| Error::InvalidType(format!("{:?}", e)))?)
     }}
 }
 
@@ -129,7 +129,7 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
     fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
         let raw = self.input.get_opt::<_, Vec<u8>>(self.index)
             .unwrap()
-            .map_err(|_| Error::InvalidType)?;
+            .map_err(|e| Error::InvalidType(format!("{:?}", e)))?;
 
         visitor.visit_seq(SeqDeserializer::new(raw.into_iter()))
     }
@@ -204,7 +204,12 @@ impl<'de, 'a> de::MapAccess<'de> for Deserializer<'a> {
     {
         let result = seed.deserialize(&mut *self);
         self.index += 1;
-        result
+        if let Err(Error::InvalidType(err)) = result {
+            let name = self.input.columns().get(self.index - 1).unwrap().name();
+            Err(Error::InvalidType(format!("{} {}", name, err)))
+        } else {
+            result
+        }
     }
 }
 
@@ -432,6 +437,36 @@ mod tests {
 
         connection.execute("DROP TABLE SpellBuu", &[]).unwrap();
     }
+
+    #[test]
+    fn missing_optional() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Buu {
+            wants_candy: bool,
+        }
+
+        let connection = setup_and_connect_to_db();
+
+        connection.execute("CREATE TABLE IF NOT EXISTS MiBuu (
+                    wants_candy BOOL
+        )", &[]).unwrap();
+
+        connection.execute("INSERT INTO MiBuu (
+            wants_candy
+        ) VALUES ($1)",
+        &[&None::<bool>]).unwrap();
+
+        let results = connection.query("SELECT wants_candy FROM MiBuu", &[]).unwrap();
+
+        let row = results.get(0);
+
+        assert_eq!(
+            super::from_row::<Buu>(row),
+            Err(super::Error::InvalidType(String::from("wants_candy Error(Conversion(WasNull))"))));
+
+        connection.execute("DROP TABLE MiBuu", &[]).unwrap();
+    }
+
 
     /*
     use postgres_derive::FromSql;

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     /// Row contained a field unknown to the data structure.
     UnknownField,
     /// Row's column type was different from the Rust data structure.
-    InvalidType,
+    InvalidType(String),
     /// Rust data structure contained a type unsupported by `serde_postgres`.
     UnsupportedType,
 }
@@ -43,7 +43,7 @@ impl error::Error for Error {
         match self {
             Error::Message(ref msg) => msg,
             Error::UnknownField => "Unknown field",
-            Error::InvalidType => "Invalid type",
+            Error::InvalidType(_) => "Invalid type",
             Error::UnsupportedType => "Type unsupported",
         }
     }


### PR DESCRIPTION
I have added better error messages to the case where the type in the struct and the sql query do not match.

I've done the quick and dirty thing with respect to the error message here, we'll want to think more about the exact nature of the desired error messages before merging.